### PR TITLE
Feature/skip

### DIFF
--- a/example/source_this
+++ b/example/source_this
@@ -1,3 +1,4 @@
+# {{ skip }}
 export FOO_BAR=12345
 export BAZ=Bif
 export BAR="This is an example"

--- a/example/will_be_ignored.conf.ignore
+++ b/example/will_be_ignored.conf.ignore
@@ -1,0 +1,1 @@
+# This file will be ignored

--- a/generator/context.go
+++ b/generator/context.go
@@ -7,6 +7,7 @@ import (
   "strings"
 )
 
+// Context type objects are passed into the template during template.Execute().
 type Context struct {
   store backend.Backend
 }
@@ -15,6 +16,8 @@ func newContext(be backend.Backend) *Context {
   return &Context{be}
 }
 
+// Get performs a lookup of the given key in the backend. Failing that,
+// it attempts to find the key in ENV.
 func (c *Context) Get(key string) string {
   if c.store != nil {
     key = strings.ToLower(key)

--- a/generator/file.go
+++ b/generator/file.go
@@ -19,6 +19,7 @@ type file struct {
   group   int
   mode    os.FileMode
   dirmode os.FileMode
+  skip    bool
 }
 
 func (f *file) setDir(dir string, args ...interface{}) string {
@@ -61,6 +62,11 @@ func (f *file) setDirMode(dm os.FileMode) string {
   return ""
 }
 
+func (f *file) setSkip() string {
+  f.skip = true
+  return ""
+}
+
 func (f *file) destination() string {
   return filepath.Join(f.dir, f.name)
 }
@@ -74,7 +80,8 @@ func parseFiles(dir string, def string) (st *stack.Stack, err error) {
 
 func walkfunc(def string, st *stack.Stack) filepath.WalkFunc {
   return func(path string, info os.FileInfo, err error) error {
-    if info.Mode().IsRegular() {
+    ext := filepath.Ext(path)
+    if info.Mode().IsRegular() && ext != ".skip" && ext != ".ignore" {
       return parseFile(path, def, st)
     }
     return nil
@@ -106,6 +113,7 @@ func newFile(path string, def string, name string) *file {
     dirmode: os.FileMode(0755),
     user:    os.Geteuid(),
     group:   os.Getegid(),
+    skip:    false,
   }
 }
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -85,6 +85,10 @@ func (g *generator) write(f *file) error {
     return err
   }
 
+  if f.skip {
+    return nil
+  }
+
   l.Info("Generating %q from %q", f.destination(), f.src)
   if _, err := os.Stat(f.dir); err != nil {
     if err = os.MkdirAll(f.dir, f.dirmode); err != nil {

--- a/generator/template_funcs.go
+++ b/generator/template_funcs.go
@@ -20,6 +20,7 @@ func newFuncMap(f *file) map[string]interface{} {
     "dir_mode":        f.setDirMode,
     "user":            f.setUser,
     "group":           f.setGroup,
+    "skip":            f.setSkip,
     "env":             os.Getenv,
     "to_json":         marshalJSON,
     "from_json":       UnmarshalJSON,

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,3 +1,5 @@
+// Package logger provides super simple logging
+// functionality for command line based programs.
 package logger
 
 import (
@@ -5,10 +7,13 @@ import (
 )
 
 var (
+  // Level is the output level
   Level int
-  Fmt   string
+  // Fmt is the log format
+  Fmt string
 )
 
+// Quiet prints msg if Level == 0
 func Quiet(msg string, args ...interface{}) {
   if Level == 0 {
     m := fmt.Sprintf(msg, args...)
@@ -16,18 +21,21 @@ func Quiet(msg string, args ...interface{}) {
   }
 }
 
+// Info prints msg if Level >= 1
 func Info(msg string, args ...interface{}) {
-  if Level == 1 {
+  if Level >= 1 {
     m := fmt.Sprintf(msg, args...)
     fmt.Printf(Fmt, m)
   }
 }
 
+// Error always prints its message as an error
 func Error(msg string, args ...interface{}) {
   m := fmt.Sprintf(msg, args...)
   fmt.Print(fmt.Errorf(Fmt, m))
 }
 
+// Debug prints msg if Level > 1
 func Debug(msg string, args ...interface{}) {
   if Level > 1 {
     m := fmt.Sprintf(msg, args...)


### PR DESCRIPTION
Adding `skip` function to templates. `skip` will cause the generator to ignore that file.
Generato will also ignore files with the extensions `.ignore` and `.skip`
